### PR TITLE
Impl `num_traits::Zero`, `num_traits::One` and `std::ops::Rem` for `Decimal`

### DIFF
--- a/src/cheats.rs
+++ b/src/cheats.rs
@@ -30,3 +30,21 @@ impl_primitive!(u64);
 impl_primitive!(i64);
 impl_primitive!(u128);
 impl_primitive!(i128);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaling_factor() {
+        assert_eq!(<i32 as Cheats<0>>::SCALING_FACTOR, 1);
+        assert_eq!(<i32 as Cheats<1>>::SCALING_FACTOR, 10);
+        assert_eq!(<i32 as Cheats<2>>::SCALING_FACTOR, 100);
+        assert_eq!(<i32 as Cheats<3>>::SCALING_FACTOR, 1000);
+
+        assert_eq!(<i64 as Cheats<0>>::SCALING_FACTOR, 1);
+        assert_eq!(<i64 as Cheats<1>>::SCALING_FACTOR, 10);
+        assert_eq!(<i64 as Cheats<2>>::SCALING_FACTOR, 100);
+        assert_eq!(<i64 as Cheats<3>>::SCALING_FACTOR, 1000);
+    }
+}

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -174,6 +174,42 @@ where
     }
 }
 
+impl<I, const D: u8> std::ops::Rem for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    type Output = Self;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        Self(self.0 % rhs.0)
+    }
+}
+
+impl<I, const D: u8> num_traits::Zero for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    #[inline]
+    fn zero() -> Self {
+        Self(I::zero())
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<I, const D: u8> num_traits::One for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    #[inline]
+    fn one() -> Self {
+        Self(I::one() * <I as crate::cheats::Cheats<D>>::SCALING_FACTOR)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -76,6 +76,31 @@ where
     }
 }
 
+impl<I, const D: u8> num_traits::Zero for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    #[inline]
+    fn zero() -> Self {
+        Self(I::zero())
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl<I, const D: u8> num_traits::One for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    #[inline]
+    fn one() -> Self {
+        Self(I::one() * <I as crate::cheats::Cheats<D>>::SCALING_FACTOR)
+    }
+}
+
 impl<I, const D: u8> Add for Decimal<I, D>
 where
     I: ScaledInteger<D>,
@@ -121,6 +146,18 @@ where
     #[inline]
     fn div(self, rhs: Self) -> Self::Output {
         Decimal(I::full_mul_div(self.0, I::SCALING_FACTOR, rhs.0))
+    }
+}
+
+impl<I, const D: u8> std::ops::Rem for Decimal<I, D>
+where
+    I: ScaledInteger<D>,
+{
+    type Output = Self;
+
+    #[inline]
+    fn rem(self, rhs: Self) -> Self::Output {
+        Self(self.0 % rhs.0)
     }
 }
 
@@ -173,43 +210,6 @@ where
     #[inline]
     fn div_assign(&mut self, rhs: Self) {
         *self = Decimal(I::full_mul_div(self.0, I::SCALING_FACTOR, rhs.0));
-    }
-}
-
-impl<I, const D: u8> std::ops::Rem for Decimal<I, D>
-where
-    I: ScaledInteger<D>,
-{
-    type Output = Self;
-
-    #[inline]
-    fn rem(self, rhs: Self) -> Self::Output {
-        Self(self.0 % rhs.0)
-    }
-}
-
-impl<I, const D: u8> num_traits::Zero for Decimal<I, D>
-where
-    I: ScaledInteger<D>,
-{
-    #[inline]
-    fn zero() -> Self {
-        Self(I::zero())
-    }
-
-    #[inline]
-    fn is_zero(&self) -> bool {
-        self.0.is_zero()
-    }
-}
-
-impl<I, const D: u8> num_traits::One for Decimal<I, D>
-where
-    I: ScaledInteger<D>,
-{
-    #[inline]
-    fn one() -> Self {
-        Self(I::one() * <I as crate::cheats::Cheats<D>>::SCALING_FACTOR)
     }
 }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -70,6 +70,7 @@ where
         }
     }
 
+    #[inline]
     pub fn is_zero(&self) -> bool {
         self.0 == I::ZERO
     }
@@ -129,6 +130,7 @@ where
 {
     type Output = Self;
 
+    #[inline]
     fn neg(self) -> Self::Output {
         Decimal(self.0.checked_neg().unwrap())
     }
@@ -180,6 +182,7 @@ where
 {
     type Output = Self;
 
+    #[inline]
     fn rem(self, rhs: Self) -> Self::Output {
         Self(self.0 % rhs.0)
     }
@@ -225,6 +228,14 @@ mod tests {
     macro_rules! test_basic_ops {
         ($underlying:ty, $decimals:literal) => {
             paste! {
+                #[test]
+                fn [<num_traits_one_ $underlying _ $decimals _add>]() {
+                    use num_traits::One;
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(1, 0).unwrap());
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(10, 1).unwrap());
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(100, 2).unwrap());
+                }
+
                 #[test]
                 fn [<$underlying _ $decimals _add>]() {
                     assert_eq!(
@@ -699,19 +710,4 @@ mod tests {
     crate::macros::apply_to_common_variants!(test_basic_ops);
     crate::macros::apply_to_common_variants!(fuzz_against_primitive);
     crate::macros::apply_to_common_variants!(differential_fuzz);
-
-    macro_rules! num_traits_one_check{
-        ($underlying:ty, $decimals:literal) => {
-            paste! {
-                #[test]
-                fn [<num_traits_one_ $underlying _ $decimals _add>]() {
-                    use num_traits::One;
-                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(1, 0).unwrap());
-                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(10, 1).unwrap());
-                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(100, 2).unwrap());
-                }
-            }
-        };
-    }
-    crate::macros::apply_to_common_variants!(num_traits_one_check);
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -699,4 +699,19 @@ mod tests {
     crate::macros::apply_to_common_variants!(test_basic_ops);
     crate::macros::apply_to_common_variants!(fuzz_against_primitive);
     crate::macros::apply_to_common_variants!(differential_fuzz);
+
+    macro_rules! num_traits_one_check{
+        ($underlying:ty, $decimals:literal) => {
+            paste! {
+                #[test]
+                fn [<num_traits_one_ $underlying _ $decimals _add>]() {
+                    use num_traits::One;
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(1, 0).unwrap());
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(10, 1).unwrap());
+                    assert_eq!(Decimal::<$underlying, $decimals>::one(), Decimal::try_from_scaled(100, 2).unwrap());
+                }
+            }
+        };
+    }
+    crate::macros::apply_to_common_variants!(num_traits_one_check);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,5 @@ pub(crate) mod macros;
 pub(crate) mod algorithms;
 
 pub use aliases::*;
-pub use cheats::Cheats;
 pub use decimal::*;
 pub use integer::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,6 @@ pub(crate) mod macros;
 pub(crate) mod algorithms;
 
 pub use aliases::*;
+pub use cheats::Cheats;
 pub use decimal::*;
 pub use integer::*;


### PR DESCRIPTION
These can be implemented easily as `I: ScaledInteger<D>` implements it as well.
Added some tests for good measure.
I'm very impressed with this crate, with it being implemented so cleanly and achieving really good performance vs competitors.