### PR TITLE
fix: parse strings without a decimal point as well in `from_str` impl

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -39,6 +39,7 @@ where
         if s.is_empty() {
             return Err(ParseDecimalError::EmptyString);
         }
+
         // Strip the sign (-0 would parse to 0 and break our output).
         let unsigned_s = s.strip_prefix('-').unwrap_or(s);
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -48,6 +48,7 @@ where
             // The number does not contain a decimal point, but we can still try and parse
             // it as an integer.
             let integer = I::from_str(s)?;
+
             return Decimal::try_from_scaled(integer, 0)
                 .ok_or(ParseDecimalError::Overflow(integer, I::ZERO));
         };

--- a/src/display.rs
+++ b/src/display.rs
@@ -45,7 +45,8 @@ where
 
         // Parse the unsigned representation.
         let Some((integer_s, fractional_s)) = unsigned_s.split_once('.') else {
-            // The number does not contain a decimal point, but we can still try and parse it as an integer.
+            // The number does not contain a decimal point, but we can still try and parse
+            // it as an integer.
             let integer = I::from_str(s)?;
             return Decimal::try_from_scaled(integer, 0)
                 .ok_or(ParseDecimalError::Overflow(integer, I::ZERO));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,5 @@ pub(crate) mod algorithms;
 
 pub use aliases::*;
 pub use decimal::*;
+pub use display::ParseDecimalError;
 pub use integer::*;


### PR DESCRIPTION
Adds support for parsing strings without a decimal point. 
Strings in the wild sometimes don't have a decimal point  but we still want to be able to parse those as integers without a fractional part.

Also publicly export `ParseDecimalError` so downstream can use it where necessary