### PR TITLE
Add `quantize_toward_zero` method to `Decimal`

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -89,13 +89,13 @@ where
     /// let d = Decimal::<i64, 5>::try_from_scaled(1165, 2).unwrap();
     /// // Allow only increments of 0.5
     /// let quantum = Decimal::<i64, 5>::try_from_scaled(5, 1).unwrap();
-    /// let q = d.quantize_toward_zero(quantum);
+    /// let q = d.quantize_round_to_zero(quantum);
     /// // 11.5 rounded down to the nearest `quantum`.
     /// assert_eq!(q, Decimal::try_from_scaled(115, 1).unwrap());
     /// ```
     #[inline]
     #[must_use]
-    pub fn quantize_toward_zero(&self, quantum: Self) -> Self {
+    pub fn quantize_round_to_zero(&self, quantum: Self) -> Self {
         // SAFETY: We know the multiplication cannot overflow as we previously divided
         // by the same number (and rust is rounding towards zero by default).
         #[allow(clippy::arithmetic_side_effects)]
@@ -412,23 +412,23 @@ mod tests {
                 fn [<$underlying _ $decimals _quantize_toward_zero_0>]() {
                     let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(5, 1).unwrap();
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(45, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(45, 1).unwrap());
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(40, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(40, 1).unwrap());
 
                     let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(2, 1).unwrap();
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(48, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(48, 1).unwrap());
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(44, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(44, 1).unwrap());
 
                     let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(4, 1).unwrap();
                     let original = Decimal::<$underlying, $decimals>::try_from_scaled(123, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(120, 1).unwrap());
+                    assert_eq!(original.quantize_round_to_zero(quantum), Decimal::try_from_scaled(120, 1).unwrap());
                 }
             }
         };

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -296,34 +296,6 @@ mod tests {
         ($underlying:ty, $decimals:literal) => {
             paste! {
                 #[test]
-                fn [<$underlying _ $decimals _quantize_toward_zero_0>]() {
-                    let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(5, 1).unwrap();
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(45, 1).unwrap());
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(40, 1).unwrap());
-                }
-
-                #[test]
-                fn [<$underlying _ $decimals _quantize_down_1>]() {
-                    let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(2, 1).unwrap();
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(48, 1).unwrap());
-
-                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
-                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(44, 1).unwrap());
-                }
-
-                #[test]
                 fn [<num_traits_one_ $underlying _ $decimals _add>]() {
                     use num_traits::One;
                     assert_eq!(
@@ -434,6 +406,29 @@ mod tests {
                     out /= Decimal::TWO;
 
                     assert_eq!(out, Decimal::ONE / Decimal::TWO);
+                }
+
+                #[test]
+                fn [<$underlying _ $decimals _quantize_toward_zero_0>]() {
+                    let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(5, 1).unwrap();
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(45, 1).unwrap());
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(40, 1).unwrap());
+
+                    let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(2, 1).unwrap();
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(61, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(60, 1).unwrap());
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(49, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(48, 1).unwrap());
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(44, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(44, 1).unwrap());
+
+                    let quantum = Decimal::<$underlying, $decimals>::try_from_scaled(4, 1).unwrap();
+                    let original = Decimal::<$underlying, $decimals>::try_from_scaled(123, 1).unwrap();
+                    assert_eq!(original.quantize_toward_zero(quantum), Decimal::try_from_scaled(120, 1).unwrap());
                 }
             }
         };


### PR DESCRIPTION
This PR adds the ability to quantize a `Decimal` to a multiple of a `quantum` (rounding towards zero as its the default rounding behaviour in rust). The name is chosen to maximize the information gained from reading it (as compared with just naming it `quantize` and expecting a different rounding behaviour).

The use cases are plenty with one example being the ability to pass exchange `PriceFilter` and `QuantityFilter`, e.g when you have a price estimate from some signal processing function like a moving average (`312.95137`, stored in `Decimal<i64, 5>`) and the exchange expects you to be quantized to the tick size of `0.5` units of the quote currency, then this method comes in handy and calling `.quantize_toward_zero(Decimal::try_from_scaled(5, 1).unwrap())` will return a `Decimal` of value `312.5`.

In principle other such methods could exist for different rounding modes, e.g `quantize_round`,  `quantize_ceil`, `quantize_floor` but those are out of scope of this PR.