### PR TITLE
Add benchmark comparing against `fpdec` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `const-decimal`.
 
 ## Unreleased
 
+- Add `fpdec_comparison` benchmark.
+- Parse strings without a decimal point.
+- Add `quantize_round_to_zero`.
+- Impl `num_traits::Zero`, `num_traits::One`, and `std::ops::Rem`.
+
 ## 0.3.0
 
 - BREAKING: Remove `from_scaled` in favor of `try_from_scaled`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "borsh",
  "criterion",
  "expect-test",
+ "fpdec",
  "malachite",
  "num-traits",
  "paste",
@@ -537,6 +538,32 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fpdec"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2c6267fe7a0c52672fe9879c22a4b5a08f11c6c987c43186141d5b0eb9745f"
+dependencies = [
+ "fpdec-core",
+ "fpdec-macros",
+]
+
+[[package]]
+name = "fpdec-core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c81a0af753d9c6e1d5f83f956699e66fe578c8002e233c831facaad1becc9f"
+
+[[package]]
+name = "fpdec-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cd2d5a6b768a966a951d753151922da390c185fcce1ee5f529dab994d8480c"
+dependencies = [
+ "fpdec-core",
+ "quote",
+]
 
 [[package]]
 name = "funty"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ criterion = "0.5.1"
 expect-test = "1.5.0"
 malachite = "0.4.16"
 proptest = "1.5.0"
+fpdec = "0.11.0"
 
 [profile.release]
 opt-level = 3
@@ -58,4 +59,9 @@ incremental = false
 [[bench]]
 name = "main"
 path = "benches/main.rs"
+harness = false
+
+[[bench]]
+name = "vs_fpdec"
+path = "benches/vs_fpdec.rs"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ thiserror = "1.0.63"
 [dev-dependencies]
 criterion = "0.5.1"
 expect-test = "1.5.0"
+fpdec = "0.11.0"
 malachite = "0.4.16"
 proptest = "1.5.0"
-fpdec = "0.11.0"
 
 [profile.release]
 opt-level = 3
@@ -62,6 +62,6 @@ path = "benches/main.rs"
 harness = false
 
 [[bench]]
-name = "vs_fpdec"
-path = "benches/vs_fpdec.rs"
+name = "fpdec_comparison"
+path = "benches/fpdec_comparison.rs"
 harness = false

--- a/benches/fpdec_comparison.rs
+++ b/benches/fpdec_comparison.rs
@@ -5,8 +5,6 @@ use fpdec::{Dec, Decimal};
 
 // Lots of black boxes, maybe overkill.
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("vs_fpdec");
-
     // Create instances here to avoid benchmarking the constructor.
     let fpdec_0 = fpdec::Decimal::new_raw(100, 0);
     let fpdec_1 = fpdec::Decimal::new_raw(110, 0);
@@ -17,71 +15,72 @@ fn criterion_benchmark(c: &mut Criterion) {
     let const_decimal_i64_0 = const_decimal::Decimal::<i64, 4>::try_from_scaled(100, 0).unwrap();
     let const_decimal_i64_1 = const_decimal::Decimal::<i64, 4>::try_from_scaled(110, 0).unwrap();
 
-    group.bench_function(&format!("fpdec_add"), |b| {
+    c.bench_function(&format!("fpdec_add"), |b| {
         b.iter(|| {
             let _ = black_box(black_box(fpdec_0) + black_box(fpdec_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i32_add"), |b| {
+    c.bench_function(&format!("const_decimal_i32_add"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i32_0) + black_box(const_decimal_i32_1));
+            black_box(black_box(const_decimal_i32_0) + black_box(const_decimal_i32_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i64_add"), |b| {
+    c.bench_function(&format!("const_decimal_i64_add"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i64_0) + black_box(const_decimal_i64_1));
+            black_box(black_box(const_decimal_i64_0) + black_box(const_decimal_i64_1));
         })
     });
 
-    group.bench_function(&format!("fpdec_sub"), |b| {
+    c.bench_function(&format!("fpdec_sub"), |b| {
         b.iter(|| {
             let _ = black_box(black_box(fpdec_0) - black_box(fpdec_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i32_sub"), |b| {
+    c.bench_function(&format!("const_decimal_i32_sub"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i32_0) - black_box(const_decimal_i32_1));
+            black_box(black_box(const_decimal_i32_0) - black_box(const_decimal_i32_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i64_sub"), |b| {
+    c.bench_function(&format!("const_decimal_i64_sub"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i64_0) - black_box(const_decimal_i64_1));
+            black_box(black_box(const_decimal_i64_0) - black_box(const_decimal_i64_1));
         })
     });
 
-    group.bench_function(&format!("fpdec_mul"), |b| {
+    c.bench_function(&format!("fpdec_mul"), |b| {
         b.iter(|| {
             let _ = black_box(black_box(fpdec_0) * black_box(fpdec_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i32_mul"), |b| {
+    c.bench_function(&format!("const_decimal_i32_mul"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i32_0) * black_box(const_decimal_i32_1));
+            black_box(black_box(const_decimal_i32_0) * black_box(const_decimal_i32_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i64_mul"), |b| {
+    c.bench_function(&format!("const_decimal_i64_mul"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i64_0) * black_box(const_decimal_i64_1));
+            black_box(black_box(const_decimal_i64_0) * black_box(const_decimal_i64_1));
         })
     });
 
-    group.bench_function(&format!("fpdec_div"), |b| {
+    c.bench_function(&format!("fpdec_div"), |b| {
         b.iter(|| {
             let _ = black_box(black_box(fpdec_0) / black_box(fpdec_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i32_div"), |b| {
+    c.bench_function(&format!("const_decimal_i32_div"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i32_0) / black_box(const_decimal_i32_1));
+            black_box(black_box(const_decimal_i32_0) / black_box(const_decimal_i32_1));
         })
     });
-    group.bench_function(&format!("const_decimal_i64_div"), |b| {
+    c.bench_function(&format!("const_decimal_i64_div"), |b| {
         b.iter(|| {
-            let _ = black_box(black_box(const_decimal_i64_0) / black_box(const_decimal_i64_1));
+            black_box(black_box(const_decimal_i64_0) / black_box(const_decimal_i64_1));
         })
     });
 
-    // Some real-world use case examples. Linear futures profit and loss calculations. Quantity denoted in BaseCurrency.
+    // Some real-world use case examples. Linear futures profit and loss
+    // calculations. Quantity denoted in BaseCurrency.
     let fpdec_entry_price = Dec!(100);
     let fpdec_exit_price = Dec!(110);
     let fpdec_qty = Dec!(5);
@@ -98,34 +97,35 @@ fn criterion_benchmark(c: &mut Criterion) {
         const_decimal::Decimal::<i64, 2>::try_from_scaled(110, 0).unwrap();
     let const_decimal_i64_qty = const_decimal::Decimal::<i64, 2>::try_from_scaled(5, 0).unwrap();
 
-    group.bench_function(&format!("fpdec_linear_futures_pnl"), |b| {
+    c.bench_function(&format!("fpdec_linear_futures_pnl"), |b| {
         b.iter(|| {
             let _ = black_box(fpdec_exit_price * fpdec_qty - fpdec_entry_price * fpdec_qty);
         })
     });
-    group.bench_function(&format!("const_decimal_i32_linear_futures_pnl"), |b| {
+    c.bench_function(&format!("const_decimal_i32_linear_futures_pnl"), |b| {
         b.iter(|| {
-            let _pnl = black_box(
+            black_box(
                 const_decimal_i32_exit_price * const_decimal_i32_qty
                     - const_decimal_i32_entry_price * const_decimal_i32_qty,
             );
         })
     });
-    group.bench_function(&format!("const_decimal_i64_linear_futures_pnl"), |b| {
+    c.bench_function(&format!("const_decimal_i64_linear_futures_pnl"), |b| {
         b.iter(|| {
-            let _pnl = black_box(
+            black_box(
                 const_decimal_i64_exit_price * const_decimal_i64_qty
                     - const_decimal_i64_entry_price * const_decimal_i64_qty,
             );
         })
     });
 
-    // Inverse futures profit and loss calculation. Quantity is denoted in QuoteCurrency.
+    // Inverse futures profit and loss calculation. Quantity is denoted in
+    // QuoteCurrency.
     let fpdec_qty = Dec!(500);
     let const_decimal_i32_qty = const_decimal::Decimal::<i32, 2>::try_from_scaled(500, 0).unwrap();
     let const_decimal_i64_qty = const_decimal::Decimal::<i64, 2>::try_from_scaled(500, 0).unwrap();
 
-    group.bench_function(&format!("fpdec_inverse_futures_pnl"), |b| {
+    c.bench_function(&format!("fpdec_inverse_futures_pnl"), |b| {
         b.iter(|| {
             let _ = black_box(
                 black_box(fpdec_qty) / black_box(fpdec_entry_price)
@@ -133,17 +133,17 @@ fn criterion_benchmark(c: &mut Criterion) {
             );
         })
     });
-    group.bench_function(&format!("const_decimal_i32_inverse_futures_pnl"), |b| {
+    c.bench_function(&format!("const_decimal_i32_inverse_futures_pnl"), |b| {
         b.iter(|| {
-            let _pnl = black_box(
+            black_box(
                 black_box(const_decimal_i32_qty) / black_box(const_decimal_i32_entry_price)
                     - black_box(const_decimal_i32_qty) / black_box(const_decimal_i32_exit_price),
             );
         })
     });
-    group.bench_function(&format!("const_decimal_i64_inverse_futures_pnl"), |b| {
+    c.bench_function(&format!("const_decimal_i64_inverse_futures_pnl"), |b| {
         b.iter(|| {
-            let _pnl = black_box(
+            black_box(
                 black_box(const_decimal_i64_qty) / black_box(const_decimal_i64_entry_price)
                     - black_box(const_decimal_i64_qty) / black_box(const_decimal_i64_exit_price),
             );

--- a/benches/vs_fpdec.rs
+++ b/benches/vs_fpdec.rs
@@ -1,0 +1,155 @@
+//! Compare `const-decimal` with [`fpdec.rs`](https://github.com/mamrhein/fpdec.rs)
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use fpdec::{Dec, Decimal};
+
+// Lots of black boxes, maybe overkill.
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("vs_fpdec");
+
+    // Create instances here to avoid benchmarking the constructor.
+    let fpdec_0 = fpdec::Decimal::new_raw(100, 0);
+    let fpdec_1 = fpdec::Decimal::new_raw(110, 0);
+
+    let const_decimal_i32_0 = const_decimal::Decimal::<i32, 4>::try_from_scaled(100, 0).unwrap();
+    let const_decimal_i32_1 = const_decimal::Decimal::<i32, 4>::try_from_scaled(110, 0).unwrap();
+
+    let const_decimal_i64_0 = const_decimal::Decimal::<i64, 4>::try_from_scaled(100, 0).unwrap();
+    let const_decimal_i64_1 = const_decimal::Decimal::<i64, 4>::try_from_scaled(110, 0).unwrap();
+
+    group.bench_function(&format!("fpdec_add"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(fpdec_0) + black_box(fpdec_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_add"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i32_0) + black_box(const_decimal_i32_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_add"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i64_0) + black_box(const_decimal_i64_1));
+        })
+    });
+
+    group.bench_function(&format!("fpdec_sub"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(fpdec_0) - black_box(fpdec_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_sub"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i32_0) - black_box(const_decimal_i32_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_sub"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i64_0) - black_box(const_decimal_i64_1));
+        })
+    });
+
+    group.bench_function(&format!("fpdec_mul"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(fpdec_0) * black_box(fpdec_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_mul"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i32_0) * black_box(const_decimal_i32_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_mul"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i64_0) * black_box(const_decimal_i64_1));
+        })
+    });
+
+    group.bench_function(&format!("fpdec_div"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(fpdec_0) / black_box(fpdec_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_div"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i32_0) / black_box(const_decimal_i32_1));
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_div"), |b| {
+        b.iter(|| {
+            let _ = black_box(black_box(const_decimal_i64_0) / black_box(const_decimal_i64_1));
+        })
+    });
+
+    // Some real-world use case examples. Linear futures profit and loss calculations. Quantity denoted in BaseCurrency.
+    let fpdec_entry_price = Dec!(100);
+    let fpdec_exit_price = Dec!(110);
+    let fpdec_qty = Dec!(5);
+
+    let const_decimal_i32_entry_price =
+        const_decimal::Decimal::<i32, 2>::try_from_scaled(100, 0).unwrap();
+    let const_decimal_i32_exit_price =
+        const_decimal::Decimal::<i32, 2>::try_from_scaled(110, 0).unwrap();
+    let const_decimal_i32_qty = const_decimal::Decimal::<i32, 2>::try_from_scaled(5, 0).unwrap();
+
+    let const_decimal_i64_entry_price =
+        const_decimal::Decimal::<i64, 2>::try_from_scaled(100, 0).unwrap();
+    let const_decimal_i64_exit_price =
+        const_decimal::Decimal::<i64, 2>::try_from_scaled(110, 0).unwrap();
+    let const_decimal_i64_qty = const_decimal::Decimal::<i64, 2>::try_from_scaled(5, 0).unwrap();
+
+    group.bench_function(&format!("fpdec_linear_futures_pnl"), |b| {
+        b.iter(|| {
+            let _ = black_box(fpdec_exit_price * fpdec_qty - fpdec_entry_price * fpdec_qty);
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_linear_futures_pnl"), |b| {
+        b.iter(|| {
+            let _pnl = black_box(
+                const_decimal_i32_exit_price * const_decimal_i32_qty
+                    - const_decimal_i32_entry_price * const_decimal_i32_qty,
+            );
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_linear_futures_pnl"), |b| {
+        b.iter(|| {
+            let _pnl = black_box(
+                const_decimal_i64_exit_price * const_decimal_i64_qty
+                    - const_decimal_i64_entry_price * const_decimal_i64_qty,
+            );
+        })
+    });
+
+    // Inverse futures profit and loss calculation. Quantity is denoted in QuoteCurrency.
+    let fpdec_qty = Dec!(500);
+    let const_decimal_i32_qty = const_decimal::Decimal::<i32, 2>::try_from_scaled(500, 0).unwrap();
+    let const_decimal_i64_qty = const_decimal::Decimal::<i64, 2>::try_from_scaled(500, 0).unwrap();
+
+    group.bench_function(&format!("fpdec_inverse_futures_pnl"), |b| {
+        b.iter(|| {
+            let _ = black_box(
+                black_box(fpdec_qty) / black_box(fpdec_entry_price)
+                    - black_box(fpdec_qty) / black_box(fpdec_exit_price),
+            );
+        })
+    });
+    group.bench_function(&format!("const_decimal_i32_inverse_futures_pnl"), |b| {
+        b.iter(|| {
+            let _pnl = black_box(
+                black_box(const_decimal_i32_qty) / black_box(const_decimal_i32_entry_price)
+                    - black_box(const_decimal_i32_qty) / black_box(const_decimal_i32_exit_price),
+            );
+        })
+    });
+    group.bench_function(&format!("const_decimal_i64_inverse_futures_pnl"), |b| {
+        b.iter(|| {
+            let _pnl = black_box(
+                black_box(const_decimal_i64_qty) / black_box(const_decimal_i64_entry_price)
+                    - black_box(const_decimal_i64_qty) / black_box(const_decimal_i64_exit_price),
+            );
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Contains benchmarks comparing this crate against `fpdec` (the previous performance champion AFAIK),
both on primitive operations and real-world uses.

TLDR:
Using `const_decimal::Decimal<i32, _>`  vs `fpdec::Decimal` for inverse futures pnl calculation gives a staggering improvement of 45x and ~15x better when using `i64` datatype.
Also `fpdec::Decimal` is 32 bytes in size vs 4 (i32) and 8 (i64) respectively for `const_decimal::Decimal` which is nicer for fast CPU caches.

I added `black_box` everywhere to avoid any sneaky optimizations by the compiler. Maybe overkill, but idk :)

Example output of  `cargo bench vs_fpdec` show the following on an `AMD EPYC 9654 (192) @ 2.400GHz`:
```shell
     Running benches/vs_fpdec.rs (target/release/deps/vs_fpdec-83de002bf491e535)
Gnuplot not found, using plotters backend
vs_fpdec/fpdec_add      time:   [2.4451 ns 2.4483 ns 2.4523 ns]
                        change: [-1.2607% -0.7954% -0.4444%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
vs_fpdec/const_decimal_i32_add
                        time:   [814.50 ps 814.84 ps 815.20 ps]
                        change: [-0.0961% -0.0533% -0.0154%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
vs_fpdec/const_decimal_i64_add
                        time:   [814.17 ps 814.27 ps 814.41 ps]
                        change: [-0.3039% -0.2341% -0.1699%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
vs_fpdec/fpdec_sub      time:   [2.4498 ns 2.4500 ns 2.4503 ns]
                        change: [+0.2042% +0.2417% +0.2773%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
vs_fpdec/const_decimal_i32_sub
                        time:   [814.23 ps 814.30 ps 814.37 ps]
                        change: [-0.0384% -0.0197% -0.0016%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
vs_fpdec/const_decimal_i64_sub
                        time:   [814.40 ps 814.82 ps 815.39 ps]
                        change: [+0.0303% +0.2686% +0.6741%] (p = 0.16 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
vs_fpdec/fpdec_mul      time:   [5.9715 ns 5.9720 ns 5.9726 ns]
                        change: [-0.0592% -0.0017% +0.0367%] (p = 0.94 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
vs_fpdec/const_decimal_i32_mul
                        time:   [1.8998 ns 1.8999 ns 1.9001 ns]
                        change: [-0.0379% -0.0257% -0.0143%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
vs_fpdec/const_decimal_i64_mul
                        time:   [4.8865 ns 4.8868 ns 4.8871 ns]
                        change: [-0.7091% -0.6783% -0.6476%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
vs_fpdec/fpdec_div      time:   [20.875 ns 20.893 ns 20.911 ns]
                        change: [-0.0012% +0.0896% +0.1809%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
vs_fpdec/const_decimal_i32_div
                        time:   [1.9108 ns 1.9127 ns 1.9148 ns]
                        change: [+0.5683% +0.6867% +0.8264%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
vs_fpdec/const_decimal_i64_div
                        time:   [4.8990 ns 4.9027 ns 4.9065 ns]
                        change: [+0.1999% +0.2549% +0.3122%] (p = 0.00 < 0.05)
                        Change within noise threshold.
vs_fpdec/fpdec_linear_futures_pnl
                        time:   [11.676 ns 11.677 ns 11.678 ns]
                        change: [+0.0726% +0.0960% +0.1268%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
vs_fpdec/const_decimal_i32_linear_futures_pnl
                        time:   [3.2695 ns 3.2700 ns 3.2705 ns]
                        change: [+0.2395% +0.3555% +0.4685%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe
vs_fpdec/const_decimal_i64_linear_futures_pnl
                        time:   [9.5042 ns 9.5049 ns 9.5057 ns]
                        change: [+0.1193% +0.1339% +0.1489%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
vs_fpdec/fpdec_inverse_futures_pnl
                        time:   [148.56 ns 148.59 ns 148.62 ns]
                        change: [+0.0942% +0.1194% +0.1442%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe
vs_fpdec/const_decimal_i32_inverse_futures_pnl
                        time:   [3.2717 ns 3.2733 ns 3.2748 ns]
                        change: [+0.5274% +0.8624% +1.4825%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
vs_fpdec/const_decimal_i64_inverse_futures_pnl
                        time:   [10.054 ns 10.055 ns 10.055 ns]
                        change: [+0.1513% +0.1756% +0.1995%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
```
