### PR TITLE
better panic messages in `FullMulDiv` impl.

### DIFF
--- a/src/full_mul_div.rs
+++ b/src/full_mul_div.rs
@@ -11,13 +11,17 @@ macro_rules! impl_primitive {
     ($primary:ty, $intermediate:ty) => {
         impl FullMulDiv for $primary {
             fn full_mul_div(self, rhs: Self, div: Self) -> Self {
+                debug_assert_ne!(div, <Self as num_traits::Zero>::zero(), "Cannot divide by zero");
                 let numer = (<$intermediate>::from(self))
                     .checked_mul(<$intermediate>::from(rhs))
-                    .unwrap();
+                    .expect("Can multiply in intermediary datatype");
                 let denom = <$intermediate>::from(div);
-                let out = numer.checked_div(denom).unwrap();
+                let out = numer
+                    .checked_div(denom)
+                    .expect("Can divide in intermediary datatype");
 
-                out.try_into().unwrap()
+                out.try_into()
+                    .expect("Can convert back into original datatype from intermediary.")
             }
         }
     };

--- a/src/full_mul_div.rs
+++ b/src/full_mul_div.rs
@@ -11,17 +11,16 @@ macro_rules! impl_primitive {
     ($primary:ty, $intermediate:ty) => {
         impl FullMulDiv for $primary {
             fn full_mul_div(self, rhs: Self, div: Self) -> Self {
-                debug_assert_ne!(div, <Self as num_traits::Zero>::zero(), "Cannot divide by zero");
                 let numer = (<$intermediate>::from(self))
                     .checked_mul(<$intermediate>::from(rhs))
-                    .expect("Can multiply in intermediary datatype");
+                    .unwrap_or_else(|| panic!("Mul overflowed; lhs={self}; rhs={rhs}"));
                 let denom = <$intermediate>::from(div);
                 let out = numer
                     .checked_div(denom)
-                    .expect("Can divide in intermediary datatype");
+                    .unwrap_or_else(|| panic!("Division by zero; numer={numer}; denom={denom}"));
 
                 out.try_into()
-                    .expect("Can convert back into original datatype from intermediary.")
+                    .unwrap_or_else(|err| panic!("Cast failed; err={err}"))
             }
         }
     };


### PR DESCRIPTION
Stumbled upon this while accidentally dividing by zero.
Just adds more explicit panic messages so its easier to see why something has failed.

Before:
```
thread 'main' panicked at /home/magewe/.cargo/git/checkouts/const-decimal-492c5c359d3ad68e/cd8c1d3/src/full_mul_div.rs:33:1:
called `Option::unwrap()` on a `None` value
```

After:
```
thread 'main' panicked at /home/magewe/MathisWellmann/const-decimal/src/full_mul_div.rs:37:1:
assertion `left != right` failed: Cannot divide by zero
  left: 0
 right: 0
```
